### PR TITLE
Data ingested into myria is now stored under /mnt

### DIFF
--- a/myriaplugin.py
+++ b/myriaplugin.py
@@ -6,7 +6,7 @@ from postgresplugin import PostgresInstaller, DEFAULT_PATH_FORMAT, DEFAULT_DATA_
 from starcluster.clustersetup import DefaultClusterSetup
 from starcluster.logger import log
 
-DEFAULT_MYRIA_POSTGRES_PORT = 5401
+DEFAULT_MYRIA_POSTGRES_PORT = 5432
 DEFAULT_MYRIA_CONSTANTS_PATH = 'src/edu/washington/escience/myria/MyriaConstants.java'
 
 # myria deployment configuration template
@@ -47,7 +47,7 @@ class MyriaInstaller(DefaultClusterSetup):
                  jvm_version="java-1.7.0-openjdk",
                  database_name='myria',
 
-                 postgres_port=5401,
+                 postgres_port=DEFAULT_MYRIA_POSTGRES_PORT,
                  postgres_version="9.1",
                  postgres_path=DEFAULT_PATH_FORMAT,
                  postgres_name=None,

--- a/postgresplugin.py
+++ b/postgresplugin.py
@@ -96,8 +96,6 @@ class PostgresInstaller(DefaultClusterSetup):
         node.ssh.execute(r'sed -i "s/^\s*\#\?\s*listen_addresses\s*=\s*''.*\?''/listen_addresses = \'{listeners}\'/ig" {path}'.format(
             listeners=listeners,
             path=path.format(version=version)))
-            #node.ssh.execute(r'sed -i "s+/var/lib/postgresql/9.1/main+/mnt/postgresdata+g" {path}'.format(
-            #path=path.format(version=version)))
 
     @staticmethod
     def set_port(node, port, path='/etc/postgresql/{version}/main/postgresql.conf', version=DEFAULT_VERSION):


### PR DESCRIPTION
Changed the initial configuration of myria so that the postgres
data_directoy points to the /mnt drive attached with star cluster
rather than the default postgres location.

Also it appears my editor removed some spaces at the end of some lines, sorry for the clutter.